### PR TITLE
fix(docu): action version in demo was incorrect

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ jobs:
 
     - name: Build Image
       id: build-image
-      uses: redhat-actions/buildah-build@v1
+      uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.IMAGE_NAME }}
         tags: ${{ env.IMAGE_TAGS }}
@@ -123,7 +123,7 @@ jobs:
 
     - name: Push To Quay
       id: push-to-quay
-      uses: redhat-actions/push-to-registry@v1
+      uses: redhat-actions/push-to-registry@v2
       with:
         image: ${{ steps.build-image.outputs.image }}
         tags: ${{ steps.build-image.outputs.tags }}


### PR DESCRIPTION
### Description

As of v2 of this action tag got renamed to tags and the later was already reflected in the readme demos.
However, the version of the action in the demos was still v1 which leads to confusion.
This PR fixes this by explicitly using v2 in the readme demos now :wink:

### Changes

* bump action version in readme demos (build actiion and push action)

### Issue

* relates to redhat-actions/buildah-build/issues/29
