### PR TITLE
chore(community-files): add basic community health files

### DIFF
--- a/.github/ ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG]"
+labels: bug
+assignees: ''
+
+---
+
+### Describe the bug
+
+<!--
+A clear and short description of what the bug is.
+-->
+
+### To Reproduce
+
+<!--
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+### Expected behavior
+
+<!--
+A clear and short description of what you expected to happen.
+-->
+
+### Version
+<!--
+e.g.
+push-to-registry:**v2**
+-->
+
+### Additional context
+<!--
+Add any other context about the problem here.
+-->

--- a/.github/ ISSUE_TEMPLATE/config.yml
+++ b/.github/ ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+
+---
+
+### Is your feature request related to a problem? Please describe.
+
+<!--
+A clear and short description of what the problem is. Ex. I'm always frustrated when [...]
+-->
+
+### Describe the solution you'd like
+
+<!--
+A clear and short description of what you want to happen.
+-->
+
+### Describe alternatives you've considered
+
+<!--
+A clear and short description of any alternative solutions or features you've considered.
+-->
+
+### Additional context
+
+<!--
+Add any other context or screenshots about the feature request here.
+-->

--- a/.github/ ISSUE_TEMPLATE/questions.md
+++ b/.github/ ISSUE_TEMPLATE/questions.md
@@ -1,0 +1,22 @@
+---
+name: Project Question
+about: Ask a question regarding this project
+title: "[QUESTION]"
+labels: question
+assignees: ''
+
+---
+
+### Checklist for Questions
+
+> Note:
+> Please make sure to at least couplet the first check. If you don't I will link the duplicate in the best case or simply close your duplicate question.
+
+* [ ] I have searched older issues/questions before opening this
+* [ ] I have tried to find the answer of my question before opening this
+
+### Question
+
+<!--
+The question you have regarding the project. Please be as specific as you can be.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+### Description
+
+<!--
+A short an simple description on what this PR aims to accomplish
+-->
+
+### Changes
+
+<!--
+A List of changes within this PR
+  * chane component A
+  * update dependency B
+  * fix function C
+  * remove deprecated function D
+-->
+
+### Issues
+
+<!--
+A List of Issues this PR aims to fix or is related to. 
+  * #IssueNumber
+  * ...
+or if it is not related to an issue
+  * n/a
+-->


### PR DESCRIPTION
### Description
This PR aims to add some basic GH Issue and PR templates to standardizing what information is expected within Issues and or PRs.

### Changes
* add basic Issue templates
* add a basic PR template

### Issues
* n/a

### Note
This is may not fit here, however I felt like proposing these as I find them very useful :wink:
I am up for discussion or simple closure of this PR if deemed not necessary here.