### PR TITLE
Update action to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,5 @@ outputs:
   registry-paths:
     description: 'A JSON array of registry paths to which the tag(s) were pushed'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
It looks like github is wanting everyone to migrate to node16:
https://github.blog/changelog/202…2-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

I see this warning in my workflows:

`
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: redhat-actions/push-to-registry
`

This PR updates the action to node16. Not sure if there's any particular testing that needs to happen, but the actions seem to work for me when I use my fork and I no longer see the warning.