### PR TITLE
Support/node20

### DIFF
--- a/.github/workflows/check-lowercase.yaml
+++ b/.github/workflows/check-lowercase.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,18 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: npm ci
       - run: npm run lint
   
   check-dist:
     name: Check Distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BUNDLE_FILE: "dist/index.js"
       BUNDLE_COMMAND: "npm run bundle"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install
         run: npm ci
@@ -33,11 +33,11 @@ jobs:
   
   check-inputs-outputs:
     name: Check Input and Output enums
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       IO_FILE: ./src/generated/inputs-outputs.ts
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ghcr-push.yaml
+++ b/.github/workflows/ghcr-push.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -12,9 +12,9 @@ on:
 jobs:
   markdown-link-check:
     name: Check links in markdown
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/manifest-build-push.yaml
+++ b/.github/workflows/manifest-build-push.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   push-quay:
     name: Build and push manifest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest podman
         if: matrix.install_latest
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@main
+        uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.IMAGE_NAME }}
           tags: ${{ env.IMAGE_TAGS }}

--- a/.github/workflows/multiple-build.yaml
+++ b/.github/workflows/multiple-build.yaml
@@ -17,7 +17,7 @@ jobs:
   build:
     name: |-
       Build with ${{ matrix.build_with }} and push${{ matrix.fully_qualified_image_name_tag && ' FQIN' || '' }} (latest: ${{ matrix.install_latest }})
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +29,7 @@ jobs:
 
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/quay-push.yaml
+++ b/.github/workflows/quay-push.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   push-quay:
     name: Build and push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -9,16 +9,16 @@ on:
 
 jobs:
   crda-scan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Scan project vulnerability with CRDA
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
-          node-version: '14'
+          node-version: '20'
 
       - name: Install CRDA
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/verify-login-push.yml
+++ b/.github/workflows/verify-login-push.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   login-and-push:
     name: Login and push image to Quay.io
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +27,7 @@ jobs:
 
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ on: [ push ]
 jobs:
   build:
     name: Build and push image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Build Image
       id: build-image
@@ -144,13 +144,13 @@ If the image to push is present in both the Docker and Podman image storage, the
 If the action pulled an image from the Docker image storage into the Podman storage, it will be cleaned up from the Podman storage before the action exits.
 
 ## Note about GitHub runners and Podman
-We recommend using `runs-on: ubuntu-20.04` since it has a newer version of Podman.
+We recommend using `runs-on: ubuntu-22.04` since it has a newer version of Podman.
 
-If you are on `ubuntu-18.04` or any other older versions of ubuntu your workflow will use an older version of Podman and may encounter issues such as [#26](https://github.com/redhat-actions/push-to-registry/issues/26).
+If you are on `ubuntu-20.04` or any other older versions of ubuntu your workflow will use an older version of Podman and may encounter issues such as [#26](https://github.com/redhat-actions/push-to-registry/issues/26).
 
 ## Troubleshooting
 Note that quay.io repositories are private by default.<br>
 
 This means that if you push an image for the first time, you will have to authenticate before pulling it, or go to the repository's settings and change its visibility.
 
-Simiarly, if you receive a 403 Forbidden from GHCR, you may have to update the Package Settings. Refer to [this issue](https://github.com/redhat-actions/push-to-registry/issues/52).
+Similarly, if you receive a 403 Forbidden from GHCR, you may have to update the Package Settings. Refer to [this issue](https://github.com/redhat-actions/push-to-registry/issues/52).

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   tags:
     description: |
       'The tag or tags of the image/manifest to push.
-      For multiple tags, seperate by whitespace. For example, "latest v1"'
+      For multiple tags, separate by whitespace. For example, "latest v1"'
     required: false
     default: 'latest'
   registry:
@@ -47,5 +47,5 @@ outputs:
   registry-paths:
     description: 'A JSON array of registry paths to which the tag(s) were pushed'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Update action to use node 20.
Updates all workflows to use newer action versions and also the environment they run on, from ubuntu 20.04 to ubuntu 22.04

### Description

Fix deprecation warning from GitHub actions when running this action.

### Related Issue(s)

https://github.com/redhat-actions/push-to-registry/issues/92

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

Make the action run on node20, not in node16
