### PR TITLE
Use rm over deprecated rmdir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -417,7 +417,7 @@ async function removeDockerPodmanImageStroage(): Promise<void> {
                 await getPodmanPath(),
                 [ ...dockerPodmanOpts, "rmi", "-a", "-f" ]
             );
-            await fs.promises.rmdir(dockerPodmanRoot, { recursive: true });
+            await fs.promises.rm(dockerPodmanRoot, { recursive: true });
         }
         catch (err) {
             core.warning(`Failed to remove podman image stroage ${dockerPodmanRoot}: ${err}`);


### PR DESCRIPTION
### Description

use rm instead of rmdir

this was officially deprecated in v16

```
(node:23073) [DEP0147] DeprecationWarning: In future versions of
Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use
fs.rm(path, { recursive: true }) instead
```

https://nodejs.org/api/deprecations.html#DEP0147

Signed-off-by: jbpratt <jbpratt78@gmail.com>

### Related Issue(s)

<!--
A List of Issues this PR aims to fix or is related to.
-->

fixes #84

### Checklist

- [ ] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [x] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

fix deprecation

<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
