### PR TITLE
fix: default tag fallback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,8 @@ async function run(): Promise<void> {
     const image = core.getInput(Inputs.IMAGE);
     const tags = core.getInput(Inputs.TAGS);
     // split tags
-    const tagsList = tags.trim().split(/\s+/);
+    const trimmedTags = tags.trim();
+    const tagsList = trimmedTags ? trimmedTags.split(/\s+/) : [];
 
     // info message if user doesn't provides any tag
     if (tagsList.length === 0) {


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description

`const tagsList = tags.trim().split(/\s+/);` did not produce an empty array when `tags` is blank, so `if (tagsList.length === 0)` wouldn't fire as intended, meaning the `DEFAULT_TAG = "latest"` path was broken.

### Related Issue(s)

<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

Fixed the `tags` parsing logic.