### PR TITLE
fix: lowercase `registry`, too

### DIFF
--- a/.github/workflows/check-lowercase.yaml
+++ b/.github/workflows/check-lowercase.yaml
@@ -10,7 +10,7 @@ on:
 env:
     IMAGE_NAME: ImageCaseTest
     IMAGE_TAGS: v1 TagCaseTest ${{ github.sha }}
-    IMAGE_REGISTRY: Ghcr.io/${{ github.repository_owner }}
+    IMAGE_REGISTRY: Ghcr.io/MixedCaseOwner
     REGISTRY_USER: ${{ github.actor }}
     REGISTRY_PASSWORD: ${{ github.token }}
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ Refer to the [`podman push`](http://docs.podman.io/en/latest/markdown/podman-man
 
 | Input Name | Description | Default |
 | ---------- | ----------- | ------- |
-| image	| Name of the image or manifest you want to push. Eg. `username/imagename` or `imagename`. Refer to [Image and Tag Inputs](https://github.com/redhat-actions/push-to-registry#image-tag-inputs). | **Required** - unless all tags include registry and image name
-| tags | The tag or tags of the image or manifest to push. For multiple tags, separate by whitespace. Refer to [Image and Tag Inputs](https://github.com/redhat-actions/push-to-registry#image-tag-inputs). | `latest`
-| registry | Hostname and optional namespace to push the image to. Eg. `quay.io` or `quay.io/username`. Refer to [Image and Tag Inputs](https://github.com/redhat-actions/push-to-registry#image-tag-inputs). | **Required** - unless all tags include registry and image name
+| image	| Name of the image or manifest you want to push. Eg. `username/imagename` or `imagename`. Refer to [Image and Tag Inputs](https://github.com/redhat-actions/push-to-registry#image-tag-inputs). Automatically lowercased for convenience. | **Required** - unless all tags include registry and image name
+| tags | The tag or tags of the image or manifest to push. For multiple tags, separate by whitespace. Refer to [Image and Tag Inputs](https://github.com/redhat-actions/push-to-registry#image-tag-inputs). Automatically lowercased for convenience. | `latest`
+| registry | Hostname and optional namespace to push the image to. Eg. `quay.io` or `quay.io/username`. Refer to [Image and Tag Inputs](https://github.com/redhat-actions/push-to-registry#image-tag-inputs). Automatically lowercased for convenience. | **Required** - unless all tags include registry and image name
 | username | Username with which to authenticate to the registry. Required unless already logged in to the registry. | None
 | password | Password, encrypted password, or access token to use to log in to the registry. Required unless already logged in to the registry. | None
 | tls-verify | Verify TLS certificates when contacting the registry. Set to `false` to skip certificate verification. | `true`

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ async function getPodmanPath(): Promise<string> {
 async function run(): Promise<void> {
     const DEFAULT_TAG = "latest";
     const image = core.getInput(Inputs.IMAGE);
+    const registry = core.getInput(Inputs.REGISTRY);
     const tags = core.getInput(Inputs.TAGS);
     // split tags
     const tagsList = tags.trim().split(/\s+/);
@@ -63,12 +64,11 @@ async function run(): Promise<void> {
         }
     }
     const normalizedImage = image.toLowerCase();
-    if (isNormalized || image !== normalizedImage) {
-        core.warning(`Reference to image and/or tag must be lowercase.`
+    const normalizedRegistry = registry.toLowerCase();
+    if (isNormalized || image !== normalizedImage || registry !== normalizedRegistry) {
+        core.warning(`Reference to image, tag, and/or registry must be lowercase.`
         + ` Reference has been converted to be compliant with standard.`);
     }
-
-    const registry = core.getInput(Inputs.REGISTRY);
     const username = core.getInput(Inputs.USERNAME);
     const password = core.getInput(Inputs.PASSWORD);
     const tlsVerify = core.getInput(Inputs.TLS_VERIFY);
@@ -83,15 +83,15 @@ async function run(): Promise<void> {
         if (!normalizedImage) {
             throw new Error(`Input "${Inputs.IMAGE}" must be provided when using non full name tags`);
         }
-        if (!registry) {
+        if (!normalizedRegistry) {
             throw new Error(`Input "${Inputs.REGISTRY}" must be provided when using non full name tags`);
         }
 
-        const registryWithoutTrailingSlash = registry.replace(/\/$/, "");
+        const registryWithoutTrailingSlash = normalizedRegistry.replace(/\/$/, "");
         const registryPath = `${registryWithoutTrailingSlash}/${normalizedImage}`;
-        core.info(`Combining image name "${normalizedImage}" and registry "${registry}" `
+        core.info(`Combining image name "${normalizedImage}" and registry "${normalizedRegistry}" `
             + `to form registry path "${registryPath}"`);
-        if (normalizedImage.indexOf("/") > -1 && registry.indexOf("/") > -1) {
+        if (normalizedImage.indexOf("/") > -1 && normalizedRegistry.indexOf("/") > -1) {
             core.warning(`"${registryPath}" does not seem to be a valid registry path. `
             + `The registry path should not contain more than 2 slashes. `
             + `Refer to the Inputs section of the readme for naming image and registry.`);
@@ -104,7 +104,7 @@ async function run(): Promise<void> {
         if (normalizedImage) {
             core.warning(`Input "${Inputs.IMAGE}" is ignored when using full name tags`);
         }
-        if (registry) {
+        if (normalizedRegistry) {
             core.warning(`Input "${Inputs.REGISTRY}" is ignored when using full name tags`);
         }
 


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description

`image` and `tags` are automatically lowercased to be OCI spec compliant, but `registry` is not. Because according to the spec, the repository namespace must also be lowercase (and the host is case-insensitive per DNS spec), `registry` should be lowercased, too.

### Related Issue(s)

<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [x] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

Lowercased `registry` in `src/index.ts` and updated the `check-lowercase.yaml` test workflow as well as the `README.md`.
