### PR TITLE
update to node24 and bump github actions

### DIFF
--- a/.github/workflows/check-lowercase.yaml
+++ b/.github/workflows/check-lowercase.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: npm ci
       - run: npm run lint
   
@@ -20,7 +20,7 @@ jobs:
       BUNDLE_FILE: "dist/index.js"
       BUNDLE_COMMAND: "npm run bundle"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install
         run: npm ci
@@ -37,7 +37,7 @@ jobs:
     env:
       IO_FILE: ./src/generated/inputs-outputs.ts
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/ghcr-push.yaml
+++ b/.github/workflows/ghcr-push.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -14,7 +14,7 @@ jobs:
     name: Check links in markdown
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/manifest-build-push.yaml
+++ b/.github/workflows/manifest-build-push.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/multiple-build.yaml
+++ b/.github/workflows/multiple-build.yaml
@@ -29,7 +29,7 @@ jobs:
 
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/quay-push.yaml
+++ b/.github/workflows/quay-push.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -13,12 +13,12 @@ jobs:
     name: Scan project vulnerability with CRDA
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install CRDA
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/verify-login-push.yml
+++ b/.github/workflows/verify-login-push.yml
@@ -27,7 +27,7 @@ jobs:
 
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # push-to-registry Changelog
 
+## v2.9
+- Update action to run on Node24. https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
+
 ## v2.8
 - Update action to run on Node20. https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
 

--- a/action.yml
+++ b/action.yml
@@ -47,5 +47,5 @@ outputs:
   registry-paths:
     description: 'A JSON array of registry paths to which the tag(s) were pushed'
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
### Description

update to Node 24 and bump GitHub Actions

### Related Issue(s)

https://github.com/redhat-actions/push-to-registry/issues/108

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

- Update action runtime from Node 20 to Node 24 (action.yml)
- Bump to actions/checkout@v7 and actions/setup-node@v6 in workflows
- Set Node 24 in the security-scan workflow
- Add v2.9 changelog entry for release 🙏 