### PR TITLE
Modernize CI workflows and harden repository security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @redhat-actions/maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/check-lowercase.yaml
+++ b/.github/workflows/check-lowercase.yaml
@@ -7,6 +7,15 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
     IMAGE_NAME: ImageCaseTest
     IMAGE_TAGS: v1 TagCaseTest ${{ github.sha }}
@@ -17,7 +26,7 @@ env:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +35,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest
@@ -36,7 +45,7 @@ jobs:
       # Build image using Buildah action
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@v3
         with:
           image: ${{ env.IMAGE_NAME }}
           tags: ${{ env.IMAGE_TAGS }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,39 @@
 name: CI checks
 on:
   push:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
     name: Run ESLint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: npm ci
       - run: npm run lint
-  
+
   check-dist:
     name: Check Distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_FILE: "dist/index.js"
       BUNDLE_COMMAND: "npm run bundle"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install
         run: npm ci
@@ -30,18 +43,18 @@ jobs:
         with:
           bundle_file: ${{ env.BUNDLE_FILE }}
           bundle_command: ${{ env.BUNDLE_COMMAND }}
-  
+
   check-inputs-outputs:
     name: Check Input and Output enums
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       IO_FILE: ./src/generated/inputs-outputs.ts
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: npm ci
-    
+
       - name: Verify Input and Output enums
         uses: redhat-actions/common/action-io-generator@v1
         with:

--- a/.github/workflows/ghcr-push.yaml
+++ b/.github/workflows/ghcr-push.yaml
@@ -7,6 +7,15 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
     IMAGE_NAME: ptr-test
     IMAGE_TAGS: v1 ${{ github.sha }}
@@ -17,7 +26,7 @@ env:
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +35,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest
@@ -36,7 +45,7 @@ jobs:
       # Build image using Buildah action
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@v3
         with:
           image: ${{ env.IMAGE_NAME }}
           tags: ${{ env.IMAGE_TAGS }}

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -9,12 +9,19 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   markdown-link-check:
     name: Check links in markdown
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/manifest-build-push.yaml
+++ b/.github/workflows/manifest-build-push.yaml
@@ -8,6 +8,13 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE_NAME: ptr-manifest
   IMAGE_TAGS: v1 ${{ github.sha }}
@@ -17,7 +24,7 @@ env:
 jobs:
   push-quay:
     name: Build and push manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +33,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest
@@ -51,7 +58,7 @@ jobs:
 
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@v3
         with:
           image: ${{ env.IMAGE_NAME }}
           tags: ${{ env.IMAGE_TAGS }}

--- a/.github/workflows/multiple-build.yaml
+++ b/.github/workflows/multiple-build.yaml
@@ -5,6 +5,13 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE_REGISTRY: quay.io
   IMAGE_NAMESPACE: redhat-github-actions
@@ -17,7 +24,7 @@ jobs:
   build:
     name: |-
       Build with ${{ matrix.build_with }} and push${{ matrix.fully_qualified_image_name_tag && ' FQIN' || '' }} (latest: ${{ matrix.install_latest }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +36,7 @@ jobs:
 
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest

--- a/.github/workflows/quay-push.yaml
+++ b/.github/workflows/quay-push.yaml
@@ -8,6 +8,13 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE_NAME: ptr-test
   IMAGE_TAGS: v1 ${{ github.sha }}
@@ -17,7 +24,7 @@ env:
 jobs:
   push-quay:
     name: Build and push image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +33,7 @@ jobs:
     steps:
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest
@@ -36,7 +43,7 @@ jobs:
       # Build image using Buildah action
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@v3
         with:
           image: ${{ env.IMAGE_NAME }}
           tags: ${{ env.IMAGE_TAGS }}

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -7,18 +7,21 @@ on:
   # schedule:
   #   - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
 jobs:
   crda-scan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     name: Scan project vulnerability with CRDA
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install CRDA
         uses: redhat-actions/openshift-tools-installer@v1

--- a/.github/workflows/verify-login-push.yml
+++ b/.github/workflows/verify-login-push.yml
@@ -8,6 +8,13 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   IMAGE_REGISTRY: quay.io
   IMAGE_NAMESPACE: redhat-github-actions
@@ -17,7 +24,7 @@ env:
 jobs:
   login-and-push:
     name: Login and push image to Quay.io
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -27,7 +34,7 @@ jobs:
 
       # Checkout push-to-registry action github repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install latest podman
         if: matrix.install_latest
@@ -44,7 +51,7 @@ jobs:
       # Build image using Buildah action
       - name: Build Image
         id: build_image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@v3
         with:
           image: ${{ env.IMAGE_NAME }}
           layers: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report security vulnerabilities by emailing the maintainers or by using [GitHub's private vulnerability reporting](https://github.com/redhat-actions/push-to-registry/security/advisories/new).
+
+Please include:
+- A description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Suggested fix (if any)
+
+We will acknowledge receipt of your report within 3 business days and aim to provide a fix within 30 days.
+
+## Supported Versions
+
+Only the latest major version is actively supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | Yes                |
+| < 2.0   | No                 |


### PR DESCRIPTION
## Summary

- **Action upgrades**: `actions/checkout` v4 to v7, `actions/setup-node` v4 to v7, `redhat-actions/buildah-build` v2 to v3 across all 9 workflows
- **Workflow hardening**: Add `permissions: contents: read` (least privilege), concurrency groups with `cancel-in-progress`, update `runs-on` to `ubuntu-24.04`, add path-ignore filters for docs-only changes on CI workflow, update node-version from 20 to 24
- **Repository security** (applied via API, already active):
  - Secret scanning and push protection: enabled
  - Default workflow token permissions: read-only
  - Force pushes on main: disabled
- **New files**: `.github/dependabot.yml` (weekly npm + actions updates), `.github/CODEOWNERS`, `SECURITY.md`

## Test plan

- [ ] CI workflow runs successfully on this PR (lint, check-dist, check-inputs-outputs)
- [ ] Verify Dependabot starts creating PRs after merge
- [ ] Integration test workflows (ghcr-push, quay-push, etc.) should run on push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)